### PR TITLE
Fixed findagrave.js

### DIFF
--- a/src/sites/findagrave.js
+++ b/src/sites/findagrave.js
@@ -14,12 +14,11 @@ module.exports = function(config, data){
   
   if( data.birthDate ) {
     query = utils.addQueryParam(query, 'GSbyrel', 'in');
-    query = utils.addQueryParam(query, 'GSby', (new Date(data.birthDate)).getFullYear());
+    query = utils.addQueryParam(query, 'GSby', utils.getYear(data.birthDate));
   }
-  
   if( data.deathDate ) {
     query = utils.addQueryParam(query, 'GSdyrel', 'in');
-    query = utils.addQueryParam(query, 'GSdy', (new Date(data.deathDate)).getFullYear());
+    query = utils.addQueryParam(query, 'GSdy', utils.getYear(data.deathDate));
   }
   
   return url + query;


### PR DESCRIPTION
find a grave test 2 was failing, it was putting a death year of 1888 in
the url. Changed (new `Date(data.deathDate)).getFullYear()` to
`utils.getYear(data.deathDate)` now 4 digit years appear to be accepted
for date fields